### PR TITLE
Removes windows specific path separators.

### DIFF
--- a/src/main/java/DB_Admin/ConfigDBadmin.java
+++ b/src/main/java/DB_Admin/ConfigDBadmin.java
@@ -38,6 +38,7 @@ package DB_Admin;
 import Utils.Parameters;
 import org.w3c.dom.*;
 import javax.servlet.http.*;
+import java.nio.file.Paths;
 import java.util.Vector;
 
 /*-----------------------------------------------------
@@ -51,8 +52,8 @@ public class ConfigDBadmin {
                       Config()
     -------------------------------------------------------*/
     public ConfigDBadmin(String basePath) {
-        String configFileName = basePath+"\\DBadmin\\tms_db_admin_config_files\\config.xml";
-        String translationsFileName = basePath+"\\translations\\DBAdminTranslations.xml";
+        String configFileName = Paths.get(basePath).resolve("DBadmin").resolve("tms_db_admin_config_files").resolve("config.xml").toString();
+        String translationsFileName = Paths.get(basePath).resolve("translations").resolve("DBAdminTranslations.xml").toString();
 
         // initialize configXmlParser
         configXmlParser = new XML_parserDBadmin();

--- a/src/main/java/Users/UsersClass.java
+++ b/src/main/java/Users/UsersClass.java
@@ -78,7 +78,7 @@ import org.w3c.dom.NodeList;
 	</user> 
 ----------------------------------------------------------------------*/
 public class UsersClass {
-    public static final String WebAppUsersXMLFilePath = "\\WEB-INF\\WebAppUSERS.xml";
+    public static final String WebAppUsersXMLFilePath = File.separator + "WEB-INF" + File.separator + "WebAppUSERS.xml";
     public final String[] UsersGroups = {"READER", "LIBRARY", "THESAURUS_TEAM", "THESAURUS_COMMITTEE", "ADMINISTRATOR"};
     public final String[] UsersGroupsGR = {"Χρήστης Αναγνώστης", "Χρήστης Βιβλιοθήκης", "Ομάδα Θησαυρού", "Επιτροπή Θησαυρού", "Διαχειριστής"};
         

--- a/src/main/java/Utils/Parameters.java
+++ b/src/main/java/Utils/Parameters.java
@@ -33,6 +33,8 @@
  */
 package Utils;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 import javax.servlet.ServletContext;
 
@@ -135,12 +137,13 @@ public class Parameters {
         initParams(BaseRealPath);
     }
 
-    public static void initParams(String basePath){
-    try {
+    public static void initParams(String basePathString){
+        Path basePath = Paths.get(basePathString);
+        try {
 
-            BaseRealPath =basePath;
+            BaseRealPath = basePathString;
 
-            String pathToXMLForPrimaryLang = basePath.concat("\\DBadmin\\tms_db_admin_config_files\\config.xml");
+            String pathToXMLForPrimaryLang = basePath.resolve("DBadmin").resolve("tms_db_admin_config_files").resolve("config.xml").toString();
             try {
 
                 DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
@@ -178,7 +181,7 @@ public class Parameters {
                 Utils.StaticClass.handleException(e);
             }
 
-            String webXMLPath=basePath.concat("\\WEB-INF\\web.xml");
+            String webXMLPath = basePath.resolve("WEB-INF").resolve("web.xml").toString();
             
             DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
             Document document = builder.parse(new File(webXMLPath));
@@ -331,7 +334,7 @@ public class Parameters {
 
 
 
-        String pathToXMLForStatuses = basePath.concat("\\translations\\SaveAll_Locale_And_Scripting.xml");
+        String pathToXMLForStatuses = basePath.resolve("translations").resolve("SaveAll_Locale_And_Scripting.xml").toString();
         try {
 
             DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
@@ -354,7 +357,7 @@ public class Parameters {
 
 
 
-        String pathToXMLForSearchCriteria = basePath.concat("\\translations\\searchcriteria.xml");
+        String pathToXMLForSearchCriteria = basePath.resolve("translations").resolve("searchcriteria.xml").toString();
         try{
 
             DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();


### PR DESCRIPTION
This changes allows me to run THEMAS on a linux machine. It should still run on windows. The changes require Java 8. If that is not ok, File.separator could be used (see src/main/java/Users/UsersClass.java).